### PR TITLE
Property code completion fixes

### DIFF
--- a/org.mapstruct.eclipse/src/org/mapstruct/eclipse/internal/AbstractAnnotationCompletionProposalComputer.java
+++ b/org.mapstruct.eclipse/src/org/mapstruct/eclipse/internal/AbstractAnnotationCompletionProposalComputer.java
@@ -26,9 +26,6 @@ import org.eclipse.jdt.core.IAnnotatable;
 import org.eclipse.jdt.core.IAnnotation;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
-import org.eclipse.jdt.core.dom.IMemberValuePairBinding;
-import org.eclipse.jdt.core.dom.IMethodBinding;
-import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.ui.text.java.ContentAssistInvocationContext;
 import org.eclipse.jdt.ui.text.java.IJavaCompletionProposalComputer;
 import org.eclipse.jdt.ui.text.java.JavaContentAssistInvocationContext;
@@ -127,20 +124,4 @@ abstract class AbstractAnnotationCompletionProposalComputer implements IJavaComp
         }
         return false;
     }
-
-    /**
-     * Returns the qualified name of the annotation which is associated with the given {@link IMemberValuePairBinding}.
-     */
-    protected String getAnnotationQualifiedName(IMemberValuePairBinding binding) {
-        IMethodBinding methodBinding = binding.getMethodBinding();
-        if ( methodBinding == null ) {
-            return null;
-        }
-        ITypeBinding declaringClass = methodBinding.getDeclaringClass();
-        if ( declaringClass == null ) {
-            return null;
-        }
-        return declaringClass.getQualifiedName();
-    }
-
 }

--- a/org.mapstruct.eclipse/src/org/mapstruct/eclipse/internal/Bindings.java
+++ b/org.mapstruct.eclipse/src/org/mapstruct/eclipse/internal/Bindings.java
@@ -18,12 +18,17 @@
  */
 package org.mapstruct.eclipse.internal;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.jdt.core.dom.IAnnotationBinding;
 import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IMemberValuePairBinding;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
 
 /**
  * Helper class to inspect various {@link IBinding}s.
@@ -39,25 +44,26 @@ public class Bindings {
      * @param type the type
      * @return the method names declared in the class or a super type of it
      */
-    public static Set<String> findAllMethodNames(ITypeBinding type) {
-        Set<String> result = new HashSet<String>();
+    public static Collection<String> findAllMethodNames(ITypeBinding type) {
+        Collection<String> result = new HashSet<String>();
 
         collectMethodNames( type, new HashSet<ITypeBinding>(), result );
 
         return result;
     }
 
-    private static void collectMethodNames(ITypeBinding curr, Set<ITypeBinding> visited, Set<String> methodNames) {
-        if ( !isJavaLangObject( curr ) && visited.add( curr ) ) {
-            for ( IMethodBinding methodBinding : curr.getDeclaredMethods() ) {
+    private static void collectMethodNames(ITypeBinding type, Set<ITypeBinding> visited,
+                                           Collection<String> methodNames) {
+        if ( !isJavaLangObject( type ) && visited.add( type ) ) {
+            for ( IMethodBinding methodBinding : type.getDeclaredMethods() ) {
                 methodNames.add( methodBinding.getName() );
             }
 
-            for ( ITypeBinding ifc : curr.getInterfaces() ) {
+            for ( ITypeBinding ifc : type.getInterfaces() ) {
                 collectMethodNames( ifc, visited, methodNames );
             }
 
-            ITypeBinding superClass = curr.getSuperclass();
+            ITypeBinding superClass = type.getSuperclass();
             if ( superClass != null ) {
                 collectMethodNames( superClass, visited, methodNames );
             }
@@ -66,5 +72,50 @@ public class Bindings {
 
     private static boolean isJavaLangObject(ITypeBinding curr) {
         return curr.getQualifiedName().equals( "java.lang.Object" );
+    }
+
+    /**
+     * @param annotations the annotations
+     * @param annotationName the fully qualified name of the annotation to look for
+     * @return {@code true}, iff the given array of annotations contains an annotation with the given name
+     */
+    public static boolean containsAnnotation(IAnnotationBinding[] annotations, String annotationName) {
+        for ( IAnnotationBinding annotation : annotations ) {
+            if ( annotation.getAnnotationType().getQualifiedName().equals( annotationName ) ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @param type the enum type
+     * @return the enum constant names of the given type
+     */
+    public static Collection<String> findAllEnumConstants(ITypeBinding type) {
+        IVariableBinding[] declaredFields = type.getDeclaredFields();
+
+        Collection<String> result = new ArrayList<String>( declaredFields.length );
+
+        for ( IVariableBinding field : declaredFields ) {
+            result.add( field.getName() );
+        }
+
+        return result;
+    }
+
+    /**
+     * Returns the qualified name of the annotation which is associated with the given {@link IMemberValuePairBinding}.
+     */
+    public static String getAnnotationQualifiedName(IMemberValuePairBinding binding) {
+        IMethodBinding methodBinding = binding.getMethodBinding();
+        if ( methodBinding == null ) {
+            return null;
+        }
+        ITypeBinding declaringClass = methodBinding.getDeclaringClass();
+        if ( declaringClass == null ) {
+            return null;
+        }
+        return declaringClass.getQualifiedName();
     }
 }

--- a/org.mapstruct.eclipse/src/org/mapstruct/eclipse/internal/MapStructAPIConstants.java
+++ b/org.mapstruct.eclipse/src/org/mapstruct/eclipse/internal/MapStructAPIConstants.java
@@ -73,4 +73,14 @@ public final class MapStructAPIConstants {
      * Member name of Mapping#ignore()
      */
     public static final String MAPPING_MEMBER_IGNORE = "ignore"; //$NON-NLS-1$
+
+    /**
+     * Fully qualified name of the annotation TargetType
+     */
+    public static final String TARGET_TYPE_FQ_NAME = "org.mapstruct.TargetType"; //$NON-NLS-1$
+
+    /**
+     * Fully qualified name of the annotation MappingTarget
+     */
+    public static final String MAPPING_TARGET_FQ_NAME = "org.mapstruct.MappingTarget"; //$NON-NLS-1$
 }


### PR DESCRIPTION
Property name completion: handle multiple sources, handle @MappingTarget/@TargetType parameters, support enum constants

I've put the commit ontop of PR #18- mainly so I could use the MapStructAPIConstants class that I introduced there... hope it's ok... :wink:
